### PR TITLE
fix: add is:inline directive to GTM script for proper rendering

### DIFF
--- a/src/layouts/DefaultHead.astro
+++ b/src/layouts/DefaultHead.astro
@@ -18,7 +18,7 @@ const finalOgImage = ogImage || defaultOgImage;
 ---
 
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script is:inline>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);


### PR DESCRIPTION
- Add is:inline to Google Tag Manager script in head
- Ensures GTM script is properly output to HTML without Astro processing
- Fixes missing GTM tracking functionality on production site