### PR TITLE
fix: update results page title from "2次申込結果発表" to "最終申込状況発表"

### DIFF
--- a/src/pages/results/main-campus/second/index.astro
+++ b/src/pages/results/main-campus/second/index.astro
@@ -28,7 +28,7 @@ const finalEnrollmentData = mainCampusSettings.finalEnrollment;
           <div class="hero__text fade-up">
             <h1 class="hero__title">
               <span class="hero__title-line1">メインキャンパス</span>
-              <span class="hero__title-line2">2次申込結果発表</span>
+              <span class="hero__title-line2">最終申込状況発表</span>
             </h1>
             <p class="hero__subtitle">Results - Main Campus - Second</p>
           </div>


### PR DESCRIPTION
Updated the hero section title on the main campus second results page to better reflect the final enrollment status rather than just second application results.

🤖 Generated with [Claude Code](https://claude.ai/code)