### PR TITLE
feat: update deadline information in main campus first results page

### DIFF
--- a/src/pages/results/main-campus/first/index.astro
+++ b/src/pages/results/main-campus/first/index.astro
@@ -90,8 +90,8 @@ console.log('firstWinnersContent:', firstWinnersContent);
                   <span class="step__label">step</span>
                   <span class="step__number">02</span>
                 </div>
-                <h4 class="step__title">下記の参加意向確認フォームリンクから参加意向を入力する。</h4>
-                <p class="step__description">10月3日（木）17時までに入力をお願いします。こちらのフォームへ回答いただくことで、当選コースへの参加が確定します。期日までに入力がない場合は、キャンセル扱いとなりますので、ご理解ください。</p>
+                <h4 class="step__title">参加意向確認フォームリンクから参加意向を入力する。</h4>
+                <p class="step__description">入力期限までに下記のフォームへ回答いただくことで、当選コースへの参加が確定します。期日までに入力がない場合は、キャンセル扱いとなりますので、ご理解ください。</p>
                 
                 {intentionButtons.length > 0 && (
                   <div class="step__button-wrapper">
@@ -147,7 +147,7 @@ console.log('firstWinnersContent:', firstWinnersContent);
                   <span class="step__number">01</span>
                 </div>
                 <h4 class="step__title">2次募集にてご希望講座を申し込む</h4>
-                <p class="step__description">まだ定員に余裕のあるコースにつきましては、10月7日（月）12時から2次募集（宗像市外在住の小中学生も応募可能）を行います。<br>先着順で応募を受け付けますので、1次募集で落選となった方、まだメインキャンパスにお申込みされていない方は、ご興味のあるコースがございましたら、ぜひお申込みください。<br>※1次募集で当選された方は、2次募集のコースへの変更はできません。</p>
+                <p class="step__description">まだ定員に余裕のあるコースにつきましては、10月10日（金）12時から2次募集（宗像市外在住の小中学生も応募可能）を行います。<br>先着順で応募を受け付けますので、1次募集で落選となった方、まだメインキャンパスにお申込みされていない方は、ご興味のあるコースがございましたら、ぜひお申込みください。<br>※1次募集で当選された方は、2次募集のコースへの変更はできません。</p>
               </div>
               
               <div class="step-connector"></div>


### PR DESCRIPTION
- Change specific date "10月3日（木）17時までに" to generic "入力期限までに下記の"
- Update second recruitment start date from "10月7日（月）12時" to "10月10日（金）12時"

🤖 Generated with [Claude Code](https://claude.ai/code)