### PR TITLE
fix: update wording from "講座" to "コース" for consistency

### DIFF
--- a/src/pages/results/main-campus/first/index.astro
+++ b/src/pages/results/main-campus/first/index.astro
@@ -146,7 +146,7 @@ console.log('firstWinnersContent:', firstWinnersContent);
                   <span class="step__label">step</span>
                   <span class="step__number">01</span>
                 </div>
-                <h4 class="step__title">2次募集にてご希望講座を申し込む</h4>
+                <h4 class="step__title">2次募集にてご希望のコースに申し込む</h4>
                 <p class="step__description">まだ定員に余裕のあるコースにつきましては、10月10日（金）12時から2次募集（宗像市外在住の小中学生も応募可能）を行います。<br>先着順で応募を受け付けますので、1次募集で落選となった方、まだメインキャンパスにお申込みされていない方は、ご興味のあるコースがございましたら、ぜひお申込みください。<br>※1次募集で当選された方は、2次募集のコースへの変更はできません。</p>
               </div>
               


### PR DESCRIPTION
Change "2次募集にてご希望講座を申し込む" to "2次募集にてご希望のコースに申し込む"
to maintain consistent terminology throughout the page.

🤖 Generated with [Claude Code](https://claude.ai/code)